### PR TITLE
Fix: Google spreadsheet export to append new creators without replacing existing data

### DIFF
--- a/src/helper/creatorsSpreadsheetService.ts
+++ b/src/helper/creatorsSpreadsheetService.ts
@@ -8,21 +8,28 @@ const CREATOR_HEADERS = ['Name', 'Email', 'Phone Number', 'Country'];
 
 /**
  * Fetches all creators from the database and exports them to Google Spreadsheet
- * Creates the spreadsheet if it doesn't exist yet
+ * Only adds new records without replacing existing ones
  * @returns Promise resolving to the spreadsheet URL
  */
 export const exportCreatorsToSpreadsheet = async (): Promise<string> => {
   try {
+    console.log('Starting export of creators to spreadsheet');
+    
     // Get environment variables
     const SPREADSHEET_ID = process.env.REGISTERED_CREATORS_SPREADSHEET_ID;
     
     if (!SPREADSHEET_ID) {
+      console.error('Missing REGISTERED_CREATORS_SPREADSHEET_ID environment variable');
       throw new Error('Missing REGISTERED_CREATORS_SPREADSHEET_ID environment variable');
     }
+    
+    console.log(`Using spreadsheet ID: ${SPREADSHEET_ID}`);
 
     // Connect to the spreadsheet
+    console.log('Connecting to Google Sheets API');
     const doc = await accessGoogleSheetAPI(SPREADSHEET_ID);
     await doc.loadInfo();
+    console.log(`Connected to spreadsheet: ${doc.title}`);
     
     // Get or create the sheet
     let sheet;
@@ -30,32 +37,56 @@ export const exportCreatorsToSpreadsheet = async (): Promise<string> => {
     // Try to get the first sheet
     if (doc.sheetCount > 0) {
       sheet = doc.sheetsByIndex[0];
+      console.log(`Found existing sheet: ${sheet.title}`);
       
+      // Load the sheet data first to ensure headers are available
+      console.log('Loading sheet data...');
+      await sheet.loadHeaderRow();
+      console.log('Sheet header row loaded');
+      
+      // Now get the headers
       try {
-        // Set the header row
-        await sheet.setHeaderRow(CREATOR_HEADERS);
+        const headers = sheet.headerValues;
+        console.log('Current headers:', headers);
+        
+        // Check if headers match expected ones
+        if (!headers || headers.length === 0 || !arraysEqual(headers, CREATOR_HEADERS)) {
+          console.log('Setting headers on existing sheet');
+          await sheet.setHeaderRow(CREATOR_HEADERS);
+          console.log('Headers updated successfully');
+        }
       } catch (headerError) {
-        console.error('Error setting headers on existing sheet:', headerError);
-        // If setting headers fails, create a new sheet
-        sheet = await doc.addSheet({ 
-          title: 'Registered Creators', 
-          headerValues: CREATOR_HEADERS 
-        });
+        console.error('Error checking headers:', headerError);
+        console.log('Attempting to set headers directly');
+        await sheet.setHeaderRow(CREATOR_HEADERS);
+        console.log('Headers set successfully');
       }
     } else {
       // No sheets exist, create a new one
+      console.log('No sheets found, creating new sheet');
       sheet = await doc.addSheet({ 
         title: 'Registered Creators', 
         headerValues: CREATOR_HEADERS 
       });
+      console.log('Created new sheet with headers');
     }
     
-    // Clear existing data (except headers)
-    if (sheet.rowCount > 1) {
-      await sheet.clearRows();
+    // Fetch all existing rows from the spreadsheet
+    console.log('Fetching existing data from spreadsheet');
+    const existingRows = await sheet.getRows();
+    console.log(`Found ${existingRows.length} existing records in spreadsheet`);
+    
+    // Create a set of existing emails for fast lookup
+    const existingEmails = new Set();
+    for (const row of existingRows) {
+      if (row.get('Email')) {
+        existingEmails.add(row.get('Email').trim().toLowerCase()); // Normalize emails for comparison
+      }
     }
+    console.log(`Found ${existingEmails.size} unique emails in spreadsheet`);
     
     // Fetch all creators from the database
+    console.log('Fetching creators from database');
     const users = await prisma.user.findMany({
       where: {
         role: 'creator',
@@ -64,26 +95,50 @@ export const exportCreatorsToSpreadsheet = async (): Promise<string> => {
         creator: true,
       },
     });
+    console.log(`Found ${users.length} creators in database`);
     
-    // Prepare the rows to add
-    const rows = users.map(user => ({
-      'Name': user.name || '',
-      'Email': user.email || '',
-      'Phone Number': user.phoneNumber || '',
-      'Country': user.country || '',
-    }));
-    
-    // Add the rows to the sheet
-    if (rows.length > 0) {
-      await sheet.addRows(rows);
+    // Identify new records that don't exist in the spreadsheet
+    const newRows = [];
+    for (const user of users) {
+      const email = user.email?.trim().toLowerCase(); // Normalize for comparison
+      if (email && !existingEmails.has(email)) {
+        newRows.push({
+          'Name': user.name || '',
+          'Email': user.email || '',
+          'Phone Number': user.phoneNumber || '',
+          'Country': user.country || '',
+        });
+      }
     }
-
-    console.log(`Using spreadsheet ID: ${process.env.REGISTERED_CREATORS_SPREADSHEET_ID}`);
+    console.log(`Identified ${newRows.length} new creators to add to spreadsheet`);
+    
+    // Add the new rows to the sheet
+    if (newRows.length > 0) {
+      console.log('Adding new rows to spreadsheet...');
+      await sheet.addRows(newRows);
+      console.log(`Successfully added ${newRows.length} new creators to spreadsheet`);
+    } else {
+      console.log('No new creators to add - spreadsheet is already up to date');
+    }
     
     // Return the URL of the spreadsheet
-    return `https://docs.google.com/spreadsheets/d/${SPREADSHEET_ID}`;
+    const spreadsheetUrl = `https://docs.google.com/spreadsheets/d/${SPREADSHEET_ID}`;
+    console.log(`Export completed. Spreadsheet URL: ${spreadsheetUrl}`);
+    return spreadsheetUrl;
   } catch (error) {
-    console.error('Error exporting creators to spreadsheet:', error);
+    console.error('Error in exportCreatorsToSpreadsheet:', error);
     throw error;
   }
 };
+
+/**
+ * Helper function to compare two arrays for equality
+ */
+function arraysEqual(a: any[], b: any[]): boolean {
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/src/helper/creatorsSpreadsheetService.ts
+++ b/src/helper/creatorsSpreadsheetService.ts
@@ -26,7 +26,6 @@ export const exportCreatorsToSpreadsheet = async (): Promise<string> => {
     console.log(`Using spreadsheet ID: ${SPREADSHEET_ID}`);
 
     // Connect to the spreadsheet
-    console.log('Connecting to Google Sheets API');
     const doc = await accessGoogleSheetAPI(SPREADSHEET_ID);
     await doc.loadInfo();
     console.log(`Connected to spreadsheet: ${doc.title}`);
@@ -40,7 +39,6 @@ export const exportCreatorsToSpreadsheet = async (): Promise<string> => {
       console.log(`Found existing sheet: ${sheet.title}`);
       
       // Load the sheet data first to ensure headers are available
-      console.log('Loading sheet data...');
       await sheet.loadHeaderRow();
       console.log('Sheet header row loaded');
       
@@ -51,28 +49,24 @@ export const exportCreatorsToSpreadsheet = async (): Promise<string> => {
         
         // Check if headers match expected ones
         if (!headers || headers.length === 0 || !arraysEqual(headers, CREATOR_HEADERS)) {
-          console.log('Setting headers on existing sheet');
           await sheet.setHeaderRow(CREATOR_HEADERS);
           console.log('Headers updated successfully');
         }
       } catch (headerError) {
         console.error('Error checking headers:', headerError);
-        console.log('Attempting to set headers directly');
         await sheet.setHeaderRow(CREATOR_HEADERS);
         console.log('Headers set successfully');
       }
     } else {
       // No sheets exist, create a new one
-      console.log('No sheets found, creating new sheet');
+
       sheet = await doc.addSheet({ 
         title: 'Registered Creators', 
         headerValues: CREATOR_HEADERS 
       });
-      console.log('Created new sheet with headers');
     }
     
     // Fetch all existing rows from the spreadsheet
-    console.log('Fetching existing data from spreadsheet');
     const existingRows = await sheet.getRows();
     console.log(`Found ${existingRows.length} existing records in spreadsheet`);
     
@@ -86,7 +80,6 @@ export const exportCreatorsToSpreadsheet = async (): Promise<string> => {
     console.log(`Found ${existingEmails.size} unique emails in spreadsheet`);
     
     // Fetch all creators from the database
-    console.log('Fetching creators from database');
     const users = await prisma.user.findMany({
       where: {
         role: 'creator',
@@ -95,8 +88,7 @@ export const exportCreatorsToSpreadsheet = async (): Promise<string> => {
         creator: true,
       },
     });
-    console.log(`Found ${users.length} creators in database`);
-    
+
     // Identify new records that don't exist in the spreadsheet
     const newRows = [];
     for (const user of users) {
@@ -110,11 +102,9 @@ export const exportCreatorsToSpreadsheet = async (): Promise<string> => {
         });
       }
     }
-    console.log(`Identified ${newRows.length} new creators to add to spreadsheet`);
     
     // Add the new rows to the sheet
     if (newRows.length > 0) {
-      console.log('Adding new rows to spreadsheet...');
       await sheet.addRows(newRows);
       console.log(`Successfully added ${newRows.length} new creators to spreadsheet`);
     } else {


### PR DESCRIPTION
## Problem
Currently, when an admin clicks the "Google Spreadsheet" button, the system replaces all existing data in the spreadsheet instead of adding only new creators. This causes data loss and creates a poor user experience.

## Solution
This PR fixes the export functionality to:
1. Only add new creators that don't already exist in the spreadsheet
2. Properly handle Google Sheets API header access
3. Add comprehensive logging for better debugging
4. Normalize email addresses to prevent duplicate entries

## Testing
- Tested with existing spreadsheet containing creators
- Verified new creators are added without duplicates
- Verified existing data is preserved

## Notes
- Added proper error handling around Google Sheets API operations